### PR TITLE
Internal Test 2 Live Changes

### DIFF
--- a/ait/dsn/plugins/AOS_to_CCSDS.py
+++ b/ait/dsn/plugins/AOS_to_CCSDS.py
@@ -104,6 +104,6 @@ class AOS_to_CCSDS(Plugin):
         if len(ccsds_packet) > 1774:
             log.info('sent oversize CCSDS packet')
             log.info(ccsds_packet)
-            log.info(self.bytes_from_previous_frame)
+            log.info(self.bytes_from_previous_frames)
         self.publish(ccsds_packet)
 

--- a/ait/dsn/plugins/AOS_to_CCSDS.py
+++ b/ait/dsn/plugins/AOS_to_CCSDS.py
@@ -9,21 +9,29 @@ class AOS_to_CCSDS(Plugin):
     '''
     def __init__(self, inputs=None, outputs=None, zmq_args=None, **kwargs):
         super().__init__(inputs, outputs, zmq_args)
-        self.bytes_from_previous_frame = None
+        self.bytes_from_previous_frames = {
+            1:None,
+            2:None,
+            4:None,
+        }
 
     def process(self, data, topic=None):
         AOS_frame_object = AOSTransFrame(data)
+        #log.info(f'incoming data to deframer of len {str(len(data))}')
         if AOS_frame_object.is_idle_frame or \
            AOS_frame_object.get('aos_data_field_type') is not AOSDataFieldType.M_PDU:
             log.debug(f"Dropping idle frame!")
             return
         else:
             first_header_pointer = AOS_frame_object.get('mpdu_first_hdr_ptr')
+            #log.info(f'first header point AOS CCSDS: {first_header_pointer}')
+            #log.info(f"VC frame count: {AOS_frame_object.get('virtual_channel_frame_count')}")
+            #log.info(f"VCID: {AOS_frame_object.get('virtual_channel_id')}")
             mpdu_packet_zone = AOS_frame_object.get('mpdu_packet_zone')
             mpdu_tuple = (first_header_pointer, mpdu_packet_zone)
-            self.process_m_pdu_tuple(mpdu_tuple)
+            self.process_m_pdu_tuple(mpdu_tuple, AOS_frame_object.get('virtual_channel_id'))
 
-    def process_m_pdu_tuple(self, input_tuple):
+    def process_m_pdu_tuple(self, input_tuple, vcid):
         # input to this function should be a tuple of format (m_pdu_hdr_pointer, m_pdu_data_zone)
         first_packet_header_pointer = input_tuple[0]
         m_pdu_data = input_tuple[1]
@@ -31,21 +39,32 @@ class AOS_to_CCSDS(Plugin):
 
         remaining_bytes_to_send = m_pdu_data
 
-        if self.bytes_from_previous_frame is not None:
-            ccsds_packet_to_send = self.bytes_from_previous_frame + m_pdu_data[0:first_packet_header_pointer]
+        if self.bytes_from_previous_frames[vcid] is not None:
+            #log.info('merging with prev frame data')
+            #log.info(self.bytes_from_previous_frames[vcid])
+            #log.info(m_pdu_data[0:first_packet_header_pointer])
+            #log.info(f'first header point: {first_packet_header_pointer}')
+            ccsds_packet_to_send = self.bytes_from_previous_frames[vcid] + m_pdu_data[0:first_packet_header_pointer]
             self.send_ccsds_packet(ccsds_packet_to_send)
-            self.bytes_from_previous_frame = None
+            self.bytes_from_previous_frames[vcid] = None
             remaining_bytes_to_send = remaining_bytes_to_send[first_packet_header_pointer:]
+            #log.info(remaining_bytes_to_send)
+            #log.info('--')
 
         while remaining_bytes_to_send is not None:
             #check for empty e0 bytes
             #TODO handle the case where there are fewer than 3 idle bytes remaining
             if remaining_bytes_to_send[0:3] == bytearray(b'\xe0\xe0\xe0'):
                 log.debug("Found repeating e0 bytes in remainder of m_pdu_zone")
+                #log.info('found repeating e0 bytes')
                 remaining_bytes_to_send = None
                 continue
 
             length_of_next_packet = self.get_packet_length_from_header(remaining_bytes_to_send[0:6])
+            if length_of_next_packet > 1774:
+                #log.info('length of next packet > 1774')
+                #log.info(remaining_bytes_to_send)
+                pass
             log.debug(f"Length of next CCSDS packet is {length_of_next_packet}")
             if length_of_next_packet == len(remaining_bytes_to_send):
                 self.send_ccsds_packet(remaining_bytes_to_send)
@@ -56,7 +75,12 @@ class AOS_to_CCSDS(Plugin):
                 remaining_bytes_to_send = remaining_bytes_to_send[length_of_next_packet:]
                 continue
             elif length_of_next_packet > len(remaining_bytes_to_send):
-                self.bytes_from_previous_frame = remaining_bytes_to_send
+                #log.info('saving data for next frame')
+                #log.info(remaining_bytes_to_send)
+                #log.info(length_of_next_packet)
+                #log.info(first_packet_header_pointer)
+                #log.info('***')
+                self.bytes_from_previous_frames[vcid] = remaining_bytes_to_send
                 remaining_bytes_to_send = None
                 continue
 
@@ -76,5 +100,10 @@ class AOS_to_CCSDS(Plugin):
         '''
         publishes a CCSDS packet to the output topic
         '''
-        log.debug(f"Sending CCSDS packet with bytes {bytes(ccsds_packet).hex()}")
+        #log.info(f"Sending CCSDS packet with bytes {bytes(ccsds_packet).hex()}")
+        if len(ccsds_packet) > 1774:
+            log.info('sent oversize CCSDS packet')
+            log.info(ccsds_packet)
+            log.info(self.bytes_from_previous_frame)
         self.publish(ccsds_packet)
+

--- a/ait/dsn/plugins/TCP.py
+++ b/ait/dsn/plugins/TCP.py
@@ -339,9 +339,12 @@ class TCP_Manager(Plugin):
 
         :returns: data from topic
         """
+        #if len(data) == 0:
+        #    log.info('TCP manager got no data')
         subs = self.topic_subscription_map[topic]
         subs = [sub for sub in subs if sub.mode is Mode.TRANSMIT]
         for sub in subs:
             sub.send(data)
+        #log.info('TCP manager publishing')
         self.publish(data)
         return data

--- a/ait/dsn/plugins/TCP.py
+++ b/ait/dsn/plugins/TCP.py
@@ -24,7 +24,7 @@ class Subscription:
     hostname: str = None
     port: int = 0
     timeout_seconds: int = 5
-    receive_size_bytes: int = 1024
+    receive_size_bytes: int = 64000
     ip: str = field(init=False)
     socket: socket = field(init=False)
     log_name: str = field(init=False)

--- a/ait/dsn/sle/frames.py
+++ b/ait/dsn/sle/frames.py
@@ -538,12 +538,16 @@ class AOSTransFrame(BaseTransferFrame):
 
         # M_PDU header: 5 bits reserved, 11 first header pointer: 07FF
         # Note: If all ones, then datafield does not contain a start of a packet
+        #ait.core.log.info(f'FRAME PY {datafield[0:2]}')
+        #ait.core.log.info(f'FRAME PY {utils.hexint(datafield[0:2])}')
         self['mpdu_first_hdr_ptr'] = utils.hexint(datafield[0:2]) & 0x07FF
 
         # Remaining: M_PDU packet zone
         # In general, this may contain a series of CCSDS packets,
         # but for now, someone downstream will handle processing it
         self['mpdu_packet_zone'] = datafield[2:]
+        #ait.core.log.info(f'FRAME PY PACKET ZONE SAMPLE {datafield[2:50]}')
+        #ait.core.log.info('--')
 
 
         # AOS Spec 4.1.4.2.3.5 If the M_PDU Packet Zone contains only Idle Data,


### PR DESCRIPTION
These changes were made **during** internal test 2

Features:

- AOS_to_CCSDS maintains separate states for each VCID, to prevent intermixing VCID frames from corrupting one another.
- 64k byte receive buffer for TCP, up from 1024. This greatly improved stability of TCP connection when AIT server is under heavy load from simultaneous file uplink and telemetry downlink. (code provided by @Mejiro-McQueen)

Also contains a bunch of debugging stuff, to be reviewed and likely removed before full GDS 2.1 release.